### PR TITLE
Fix infinite recursion

### DIFF
--- a/simplify.go
+++ b/simplify.go
@@ -21,7 +21,7 @@ func SimplifyPath(points []Point, ep float64) []Point {
 }
 
 func seekMostDistantPoint(l Line, points []Point) (idx int, maxDist float64) {
-	for i := 0; i < len(points); i++ {
+	for i := 1; i < len(points)-1; i++ {
 		d := l.DistanceToPoint(points[i])
 		if d > maxDist {
 			maxDist = d


### PR DESCRIPTION
Hi! Thank you for this great implementation in Go. It's very simple and I was able to customize it easily (my requirements are to always preserve certain points, regardless of their distance from the line).

I encountered infinite recursion on some data sets, and after careful study of https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm and the JS implementation here: https://karthaus.nl/rdp/ (their link to the JS code is broken, it's actually https://karthaus.nl/rdp/js/rdp2.js) I noticed a subtle difference:

```js
    for (var i=1;i<points.length-1;i++){
        var cDist=distanceFromPointToLine(points[i],firstPoint,lastPoint);
        
        if (cDist>dist){
            dist=cDist;
            index=i;
        }
    }
```

The Wikipedia pseudo-code (albeit written by the same person) has a similar loop:

```lua
    for i = 2 to (end - 1) {
```

I noticed that this implementation wasn't converging when the outlier data point was at the end, thus it was passed in to both left and right sides.

Anyway, this fixed the bug for me. I don't know for sure if there's any other subtle differences in your implementation to the reference one, so let me know if my fix isn't right. But I think it is.

Cheers!